### PR TITLE
Feature/add tenants for get companies on prem

### DIFF
--- a/src/Communication.Codeunit.al
+++ b/src/Communication.Codeunit.al
@@ -45,16 +45,14 @@ codeunit 50103 "ENVHUB Communication"
         ENVHUBHttp: Codeunit "ENVHUB Http";
         EnvironmentInformation: Codeunit "Environment Information";
         Method: Option Get,Post,Patch;
-        baseUrl: Text;
-
+        saasUrlLbl: Label 'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/v1.0/companies';
+        onPremUrlLbl: Label '%1/api/v1.0/companies?tenant=%2';
     begin
         if ENVHUBSetup.Get() then;
         if EnvironmentInformation.IsSaaS() then begin
-            baseUrl := 'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/v1.0/companies';
-            exit(ENVHUBHttp.RequestMessage(StrSubstNo(baseUrl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
-        end else begin
-            baseUrl := ENVHUBSetup."Base URL" + '/api/v1.0/companies?tenant=%1';
-            exit(ENVHUBHttp.RequestMessage(StrSubstNo(baseUrl, environmentName), Method::Get, '')); //Change of baseUrl with tenant/environment name
+            exit(ENVHUBHttp.RequestMessage(StrSubstNo(saasUrlLbl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
+        end else begin 
+            exit(ENVHUBHttp.RequestMessage(StrSubstNo(onPremUrlLbl, ENVHUBSetup."Base URL", environmentName), Method::Get, '')); //Change of baseUrl with tenant/environment name
         end;
     end;
 }

--- a/src/Communication.Codeunit.al
+++ b/src/Communication.Codeunit.al
@@ -52,7 +52,7 @@ codeunit 50103 "ENVHUB Communication"
         if EnvironmentInformation.IsSaaS() then begin
             baseUrl := 'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/v1.0/companies';
             exit(ENVHUBHttp.RequestMessage(StrSubstNo(baseUrl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
-        end else begin 
+        end else begin
             baseUrl := ENVHUBSetup."Base URL" + '/api/v1.0/companies?tenant=%1';
             exit(ENVHUBHttp.RequestMessage(StrSubstNo(baseUrl, environmentName), Method::Get, '')); //Change of baseUrl with tenant/environment name
         end;

--- a/src/Communication.Codeunit.al
+++ b/src/Communication.Codeunit.al
@@ -45,13 +45,13 @@ codeunit 50103 "ENVHUB Communication"
         ENVHUBHttp: Codeunit "ENVHUB Http";
         EnvironmentInformation: Codeunit "Environment Information";
         Method: Option Get,Post,Patch;
-        saasUrlLbl: Label 'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/v1.0/companies';
-        onPremUrlLbl: Label '%1/api/v1.0/companies?tenant=%2';
+        SaasUrlLbl: Label 'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/v1.0/companies', comment = '%1 = Tenant ID, %2 = Environment name';
+        OnPremUrlLbl: Label '%1/api/v1.0/companies?tenant=%2', comment = '%1 = Base URL, %2 = Environment name';
     begin
         if ENVHUBSetup.Get() then;
         if EnvironmentInformation.IsSaaS() then
-            exit(ENVHUBHttp.RequestMessage(StrSubstNo(saasUrlLbl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
+            exit(ENVHUBHttp.RequestMessage(StrSubstNo(SaasUrlLbl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
         else
-            exit(ENVHUBHttp.RequestMessage(StrSubstNo(onPremUrlLbl, ENVHUBSetup."Base URL", environmentName), Method::Get, '')); //Change of baseUrl with tenant/environment name
+            exit(ENVHUBHttp.RequestMessage(StrSubstNo(OnPremUrlLbl, ENVHUBSetup."Base URL", environmentName), Method::Get, ''));
     end;
 }

--- a/src/Communication.Codeunit.al
+++ b/src/Communication.Codeunit.al
@@ -51,7 +51,7 @@ codeunit 50103 "ENVHUB Communication"
         if ENVHUBSetup.Get() then;
         if EnvironmentInformation.IsSaaS() then begin
             exit(ENVHUBHttp.RequestMessage(StrSubstNo(saasUrlLbl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
-        end else begin 
+        end else begin
             exit(ENVHUBHttp.RequestMessage(StrSubstNo(onPremUrlLbl, ENVHUBSetup."Base URL", environmentName), Method::Get, '')); //Change of baseUrl with tenant/environment name
         end;
     end;

--- a/src/Communication.Codeunit.al
+++ b/src/Communication.Codeunit.al
@@ -45,12 +45,16 @@ codeunit 50103 "ENVHUB Communication"
         ENVHUBHttp: Codeunit "ENVHUB Http";
         EnvironmentInformation: Codeunit "Environment Information";
         Method: Option Get,Post,Patch;
-        UrlLbl: Label 'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/v1.0/companies', comment = '%1 = Tenant ID, %2 = Environment name';
+        baseUrl: Text;
+
     begin
         if ENVHUBSetup.Get() then;
-        if EnvironmentInformation.IsSaaS() then
-            exit(ENVHUBHttp.RequestMessage(StrSubstNo(UrlLbl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
-        else
-            exit(ENVHUBHttp.RequestMessage(StrSubstNo(ENVHUBSetup."Base URL"), Method::Get, '')); //Change of baseUrl
+        if EnvironmentInformation.IsSaaS() then begin
+            baseUrl := 'https://api.businesscentral.dynamics.com/v2.0/%1/%2/api/v1.0/companies';
+            exit(ENVHUBHttp.RequestMessage(StrSubstNo(baseUrl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
+        end else begin 
+            baseUrl := ENVHUBSetup."Base URL" + '/api/v1.0/companies?tenant=%1';
+            exit(ENVHUBHttp.RequestMessage(StrSubstNo(baseUrl, environmentName), Method::Get, '')); //Change of baseUrl with tenant/environment name
+        end;
     end;
 }

--- a/src/Communication.Codeunit.al
+++ b/src/Communication.Codeunit.al
@@ -49,10 +49,9 @@ codeunit 50103 "ENVHUB Communication"
         onPremUrlLbl: Label '%1/api/v1.0/companies?tenant=%2';
     begin
         if ENVHUBSetup.Get() then;
-        if EnvironmentInformation.IsSaaS() then begin
+        if EnvironmentInformation.IsSaaS() then
             exit(ENVHUBHttp.RequestMessage(StrSubstNo(saasUrlLbl, ENVHUBSetup."Tenant ID", environmentName), Method::Get, ''))
-        end else begin
+        else
             exit(ENVHUBHttp.RequestMessage(StrSubstNo(onPremUrlLbl, ENVHUBSetup."Base URL", environmentName), Method::Get, '')); //Change of baseUrl with tenant/environment name
-        end;
     end;
 }

--- a/src/Setup.Page.al
+++ b/src/Setup.Page.al
@@ -50,7 +50,7 @@ page 50102 "ENVHUB Setup"
                 field(BaseUrl; rec."Base URL")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the redirect base URL api of the application that will be used to the Business Central integration. Like https://nav.contoso.com:7048/bc/api/v2.0/v1.0/companies.';
+                    ToolTip = 'Specifies the redirect base URL api of the application that will be used to the Business Central integration. Like https://nav.contoso.com:7048/bc.';
                     Visible = not SaaSEnvironment;
                 }
             }


### PR DESCRIPTION
Enhanced the GetAllCompaniesOfEnvironment procedure to differentiate between SaaS and on-premises environments.
Updated the base URL construction for on-premises environments to include the tenant name as a query parameter.
Ensured that the HTTP request method remains consistent for both environment types.