### PR TITLE
Enhance Schedule Export and Update Setup Page

### DIFF
--- a/src/ScheduleExport.Codeunit.al
+++ b/src/ScheduleExport.Codeunit.al
@@ -52,6 +52,8 @@ codeunit 50100 "ENVHUB Schedule Export"
 
                 if (TimeToRun <> 0DT) then begin
                     JobQueueEntry."Earliest Start Date/Time" := TimeToRun;
+                end else begin
+                    JobQueueEntry."Earliest Start Date/Time" := CurrentDateTime();
                 end;
 
                 JobQueueEntry.Modify(true);
@@ -82,6 +84,8 @@ codeunit 50100 "ENVHUB Schedule Export"
 
             if (TimeToRun <> 0DT) then begin
                 JobQueueEntry."Earliest Start Date/Time" := TimeToRun;
+            end else begin
+                JobQueueEntry."Earliest Start Date/Time" := CurrentDateTime();
             end;
 
             JobQueueEntry.Modify(true);

--- a/src/ScheduleExport.Codeunit.al
+++ b/src/ScheduleExport.Codeunit.al
@@ -18,7 +18,8 @@ codeunit 50100 "ENVHUB Schedule Export"
         DelayByRunAgain: Integer;
         InactivityTimeoutPeriod: Integer;
         StartingTime: Time;
-        EndingTime: Time)
+        EndingTime: Time;
+        TimeToRun: DateTime)
     var
         JobQueueEntry: Record "Job Queue Entry";
         JobQueueCategory: Record "Job Queue Category";
@@ -48,7 +49,11 @@ codeunit 50100 "ENVHUB Schedule Export"
                     JobQueueEntry."Run on Sundays" := Sunday;
                     JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
                 end;
-                JobQueueEntry."Earliest Start Date/Time" := CurrentDateTime();
+
+                if (TimeToRun <> 0DT) then begin
+                    JobQueueEntry."Earliest Start Date/Time" := TimeToRun;
+                end;
+
                 JobQueueEntry.Modify(true);
                 JobQueueEntry.SetStatus(JobQueueEntry.Status::Ready);
             end;
@@ -74,7 +79,11 @@ codeunit 50100 "ENVHUB Schedule Export"
                 JobQueueEntry."Run on Sundays" := Sunday;
                 JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
             end;
-            JobQueueEntry."Earliest Start Date/Time" := CurrentDateTime();
+
+            if (TimeToRun <> 0DT) then begin
+                JobQueueEntry."Earliest Start Date/Time" := TimeToRun;
+            end;
+
             JobQueueEntry.Modify(true);
             JobQueueEntry.ScheduleTask();
         end;

--- a/src/ScheduleExport.Page.al
+++ b/src/ScheduleExport.Page.al
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-page 50105 "ANVHUB Schedule Export"
+page 50105 "ENVHUB Schedule Export"
 {
     PageType = Card;
     Caption = 'Schedule Export';

--- a/src/Setup.Page.al
+++ b/src/Setup.Page.al
@@ -22,6 +22,7 @@ page 50102 "ENVHUB Setup"
                 field("Client ID"; ClientID)
                 {
                     ApplicationArea = All;
+                    ExtendedDatatype = Masked;
                     Tooltip = 'Specifies the application client ID for the Azure App Registration that accesses the storage account.';
 
                     trigger OnValidate()

--- a/src/Setup.Page.al
+++ b/src/Setup.Page.al
@@ -22,7 +22,6 @@ page 50102 "ENVHUB Setup"
                 field("Client ID"; ClientID)
                 {
                     ApplicationArea = All;
-                    ExtendedDatatype = Masked;
                     Tooltip = 'Specifies the application client ID for the Azure App Registration that accesses the storage account.';
 
                     trigger OnValidate()


### PR DESCRIPTION
This PR includes the following changes:

**ScheduleExport.Page.al:**
Renamed page 50105 "ANVHUB Schedule Export" to 50105 "ENVHUB Schedule Export" to correct the name.

**ScheduleExport.Codeunit.al-1:**
Added the TimeToRun parameter to the CreateJobQueueEntry procedure to allow specifying the earliest start date/time for job queue entries.

**Setup.Page.al:**
Removed the mask from the ClientID field to allow users to see the client ID.
These changes improve the accuracy of the page name, enhance the scheduling functionality by allowing a specific start time for job queue entries, and improve usability by allowing users to see the client ID.
