### PR TITLE
Removed Visible property from TenantID

### DIFF
--- a/src/Setup.Page.al
+++ b/src/Setup.Page.al
@@ -17,7 +17,6 @@ page 50102 "ENVHUB Setup"
                 {
                     ApplicationArea = All;
                     ToolTip = 'Specifies the tenant ID where the enviroment is located.';
-                    Visible = SaaSEnvironment;
                 }
                 field("Client ID"; ClientID)
                 {


### PR DESCRIPTION
TenantID is required no matter what kind of environment you're on, as it is needed for the retrieval of the accessToken.