### PR TITLE
Removal of Validate/assignment of RecurringJob field

### DIFF
--- a/src/ScheduleExport.Codeunit.al
+++ b/src/ScheduleExport.Codeunit.al
@@ -39,6 +39,7 @@ codeunit 50100 "ENVHUB Schedule Export"
                 JobQueueEntry."Ending Time" := EndingTime;
                 JobQueueEntry."Inactivity Timeout Period" := InactivityTimeoutPeriod;
                 if RecurringJob then begin
+                    JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
                     JobQueueEntry.Validate("Run on Mondays", Monday);
                     JobQueueEntry.Validate("Run on Tuesdays", Tuesday);
                     JobQueueEntry.Validate("Run on Wednesdays", Wednesday);
@@ -46,7 +47,6 @@ codeunit 50100 "ENVHUB Schedule Export"
                     JobQueueEntry.Validate("Run on Fridays", Friday);
                     JobQueueEntry.Validate("Run on Saturdays", Saturday);
                     JobQueueEntry.Validate("Run on Sundays", Sunday);
-                    JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
                 end;
 
                 if (TimeToRun <> 0DT) then
@@ -69,6 +69,7 @@ codeunit 50100 "ENVHUB Schedule Export"
             JobQueueEntry."Ending Time" := EndingTime;
             JobQueueEntry."Inactivity Timeout Period" := InactivityTimeoutPeriod;
             if RecurringJob then begin
+                JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
                 JobQueueEntry.Validate("Run on Mondays", Monday);
                 JobQueueEntry.Validate("Run on Tuesdays", Tuesday);
                 JobQueueEntry.Validate("Run on Wednesdays", Wednesday);
@@ -76,7 +77,6 @@ codeunit 50100 "ENVHUB Schedule Export"
                 JobQueueEntry.Validate("Run on Fridays", Friday);
                 JobQueueEntry.Validate("Run on Saturdays", Saturday);
                 JobQueueEntry.Validate("Run on Sundays", Sunday);
-                JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
             end;
 
             if (TimeToRun <> 0DT) then

--- a/src/ScheduleExport.Codeunit.al
+++ b/src/ScheduleExport.Codeunit.al
@@ -33,20 +33,19 @@ codeunit 50100 "ENVHUB Schedule Export"
             JobQueueEntry.SetRange("Object ID to Run", Codeunit::"ADLSE Execution");
             if JobQueueEntry.FindFirst() then begin
                 JobQueueEntry.SetStatus(JobQueueEntry.Status::"On Hold");
-                JobQueueEntry.Validate("Recurring Job", RecurringJob);
                 JobQueueEntry."Maximum No. of Attempts to Run" := MaximumNoofAttemptstoRun;
                 JobQueueEntry."Rerun Delay (sec.)" := RerunDelay;
                 JobQueueEntry."Starting Time" := StartingTime;
                 JobQueueEntry."Ending Time" := EndingTime;
                 JobQueueEntry."Inactivity Timeout Period" := InactivityTimeoutPeriod;
                 if RecurringJob then begin
-                    JobQueueEntry."Run on Mondays" := Monday;
-                    JobQueueEntry."Run on Tuesdays" := Tuesday;
-                    JobQueueEntry."Run on Wednesdays" := Wednesday;
-                    JobQueueEntry."Run on Thursdays" := Thursdays;
-                    JobQueueEntry."Run on Fridays" := Friday;
-                    JobQueueEntry."Run on Saturdays" := Saturday;
-                    JobQueueEntry."Run on Sundays" := Sunday;
+                    JobQueueEntry.Validate("Run on Mondays", Monday);
+                    JobQueueEntry.Validate("Run on Tuesdays", Tuesday);
+                    JobQueueEntry.Validate("Run on Wednesdays", Wednesday);
+                    JobQueueEntry.Validate("Run on Thursdays", Thursdays);
+                    JobQueueEntry.Validate("Run on Fridays", Friday);
+                    JobQueueEntry.Validate("Run on Saturdays", Saturday);
+                    JobQueueEntry.Validate("Run on Sundays", Sunday);
                     JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
                 end;
 
@@ -64,20 +63,19 @@ codeunit 50100 "ENVHUB Schedule Export"
             JobQueueEntry.Validate("Object ID to Run", CODEUNIT::"ADLSE Execution");
             JobQueueEntry.Insert(true);
             JobQueueEntry.Description := JobQueueCategory.Description;
-            JobQueueEntry.Validate("Recurring Job", RecurringJob);
             JobQueueEntry."Maximum No. of Attempts to Run" := MaximumNoofAttemptstoRun;
             JobQueueEntry."Rerun Delay (sec.)" := RerunDelay;
             JobQueueEntry."Starting Time" := StartingTime;
             JobQueueEntry."Ending Time" := EndingTime;
             JobQueueEntry."Inactivity Timeout Period" := InactivityTimeoutPeriod;
             if RecurringJob then begin
-                JobQueueEntry."Run on Mondays" := Monday;
-                JobQueueEntry."Run on Tuesdays" := Tuesday;
-                JobQueueEntry."Run on Wednesdays" := Wednesday;
-                JobQueueEntry."Run on Thursdays" := Thursdays;
-                JobQueueEntry."Run on Fridays" := Friday;
-                JobQueueEntry."Run on Saturdays" := Saturday;
-                JobQueueEntry."Run on Sundays" := Sunday;
+                JobQueueEntry.Validate("Run on Mondays", Monday);
+                JobQueueEntry.Validate("Run on Tuesdays", Tuesday);
+                JobQueueEntry.Validate("Run on Wednesdays", Wednesday);
+                JobQueueEntry.Validate("Run on Thursdays", Thursdays);
+                JobQueueEntry.Validate("Run on Fridays", Friday);
+                JobQueueEntry.Validate("Run on Saturdays", Saturday);
+                JobQueueEntry.Validate("Run on Sundays", Sunday);
                 JobQueueEntry."No. of Minutes between Runs" := MinBetweenRuns;
             end;
 


### PR DESCRIPTION
removed RecurringJob assignment/validate. The way it was implemented didn't work. The Validate on the "Run on x days" triggers the SetRecurringField() procedure which in turn sets the value for RecurringJob as true if one of the days is set to true.