### PR TITLE
Use SecretText for AccessToken and bump version to 27.0.0.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "id": "07b33421-b3f4-4130-a951-6ce4c5bf1cf4",
   "name": "bc2adls Environment Hub",
   "publisher": "The bc2adls team",
-  "version": "25.0.0.7",
+  "version": "27.0.0.0",
   "brief": "",
   "description": "",
   "privacyStatement": "",
@@ -15,12 +15,12 @@
       "publisher": "The bc2adls team",
       "name": "Azure Data Lake Storage Export",
       "id": "1688530c-452c-4b06-8947-ab4bf5b26053",
-      "version": "2.13.0.0"
+      "version": "1.0.0.0"
     } 
   ],
   "screenshots": [],
-  "platform": "25.0.0.0",
-  "application": "25.0.0.0",
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
   "idRanges": [
     {
       "from": 50100,

--- a/src/Http.Codeunit.al
+++ b/src/Http.Codeunit.al
@@ -13,7 +13,7 @@ codeunit 50101 "ENVHUB Http"
         ResponseMessage: HttpResponseMessage;
         JsonResponse: JsonObject;
         [NonDebuggable]
-        AccessToken: Text;
+        AccessToken: SecretText;
         JsonContent: Text;
         Content: HttpContent;
         ContentHeaders: HttpHeaders;
@@ -31,7 +31,7 @@ codeunit 50101 "ENVHUB Http"
             RequestMessage.Content(Content);
         end;
 
-        Client.DefaultRequestHeaders().Add('Authorization', StrSubstNo('Bearer %1', AccessToken));
+        Client.DefaultRequestHeaders().Add('Authorization', SecretStrSubstNo('Bearer %1', AccessToken));
         Client.DefaultRequestHeaders().Add('Accept', 'application/json');
 
         if Client.Send(RequestMessage, ResponseMessage) then begin
@@ -44,12 +44,12 @@ codeunit 50101 "ENVHUB Http"
     end;
 
     [NonDebuggable]
-    local procedure GetAccessToken(): Text
+    local procedure GetAccessToken(): SecretText
     var
         OAuth2: Codeunit OAuth2;
         Credentials: Codeunit "ENVHUB Credentials";
         Setup: Record "ENVHUB Setup";
-        AccessToken: Text;
+        AccessToken: SecretText;
         AuthCodeError: Text;
         Scopes: List of [Text];
         UrlLbl: label 'https://login.microsoftonline.com/%1/oauth2/v2.0/token', comment = '%1 = tenant ID';
@@ -68,7 +68,7 @@ codeunit 50101 "ENVHUB Http"
             Scopes,
             AccessToken);
 
-        if (AccessToken = '') or (AuthCodeError <> '') then
+        if (AccessToken.IsEmpty()) or (AuthCodeError <> '') then
             Error(AuthCodeError);
 
         exit(AccessToken);


### PR DESCRIPTION
## Changes

- **Security**: Changed \AccessToken\ from \Text\ to \SecretText\ in \Http.Codeunit.al\ to prevent token exposure in debugging/logging
- **Security**: Use \SecretStrSubstNo\ for Bearer token header construction
- **Security**: Use \AccessToken.IsEmpty()\ instead of empty string comparison
- **Version**: Updated app version to \27.0.0.0\
- **Version**: Updated platform and application versions